### PR TITLE
fix(cache): switch to filesystem backend for CachedSession to resolve locking issues

### DIFF
--- a/tstickers/caching.py
+++ b/tstickers/caching.py
@@ -11,8 +11,8 @@ from requests_cache.session import CachedSession
 
 # requests_cache
 cachedSession = CachedSession(
-	".cache/tstickers.requests.sqlite",
-	backend="sqlite",
+	".cache/tstickers.requests",
+	backend="filesystem",
 	expire_after=60 * 60 * 12,
 	allowable_codes=(200,),
 	allowable_methods=("GET", "POST"),


### PR DESCRIPTION
### Purpose of This Pull Request

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other (please explain):

### Overview of Changes

Fix the "sqlite: bad parameter or other api misuse" error reported on Ubuntu, Windows, and Android by changing the `requests_cache` backend from sqlite to filesystem.

This uses a directory-based cache instead of a single file, eliminating locking problems in concurrent environments.

No breaking changes; cache behavior remains compatible.

### Related Issue

Fixes #10, #11